### PR TITLE
fix: expect whitespace after prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import core from '@actions/core'
 import { context } from '@actions/github'
 
-const prRegex = new RegExp('^(chore|docs|feat|fix|perf|refactor|style|test|build|revert)((.+))?:(.+)');
+const prRegex = new RegExp('^(chore|docs|feat|fix|perf|refactor|style|test|build|revert)((.+))?: (.+)');
 const branchesToIgnore = [
   'main',
   'master'


### PR DESCRIPTION
[This commit](https://github.com/warp-ds/icons/commit/e0827e7bd9c6798f69195874e3af1b3608afc5e4) not getting released shows that semantic-release doesn’t like it when prefix is not followed by an empty space (`feat:some PR` instead of `feat: some PR`). 

This change should fix future pr-linter jobs to pick that up. 